### PR TITLE
Migrate from master and slave phrasing

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -50,15 +50,15 @@ func (r *Redis_c) Connect (ip string, port int) (err error) {
 
 /*! \brief Sets up all the connection pools that we'll need in the future
 */
-func (r *Redis_c) Check(masterFlag bool) (error) {
+func (r *Redis_c) Check(mainFlag bool) (error) {
     //do a ping to make sure we got what we expected
     if r.ping() {
-        if masterFlag {
-            //ping worked, now let's see if we can set things as we expect this to be the master
+        if mainFlag {
+            //ping worked, now let's see if we can set things as we expect this to be the main
             if err := r.set("toggle_toggle", time.Now().Format("2006-01-02 15:04:05")); err != nil {
-                //if ping works but set doesn't, assume we had a fail over and need to reset this as the master
-                fmt.Println("Master unable to be written to, resetting slave of no one")
-                return r.Slaveof ("no", "one")  //return this if it errors
+                //if ping works but set doesn't, assume we had a fail over and need to reset this as the main
+                fmt.Println("Main unable to be written to, resetting subordinate of no one")
+                return r.Subordinateof ("no", "one")  //return this if it errors
             }
         }
 
@@ -68,9 +68,9 @@ func (r *Redis_c) Check(masterFlag bool) (error) {
     }
 }
 
-/*! \brief Tells the redis server who it should be a slave of
+/*! \brief Tells the redis server who it should be a subordinate of
 */
-func (r *Redis_c) Slaveof (ip, port string) (error) {
+func (r *Redis_c) Subordinateof (ip, port string) (error) {
     if r.TestingFlag { return nil } //just testing
     _, err := r.cachePool.Cmd("SLAVEOF", ip, port).Bytes()
     return err

--- a/toggle/main.go
+++ b/toggle/main.go
@@ -1,30 +1,30 @@
 /*! \file main.go
     \brief Main file/entry point for Toggle (toggle for redis)
 
-    This app is designed to switch between two machines both running redis as a master/slave setup
-    The goal is to be able to "toggle" back and forth between the machines.  When the "master" is no longer ping'able
-    we'll issue a "slaveof no one" to the "slave".
-    It will then swap the ip address of the nginx load balancer to point to the new "master" node
-    The app will continue to attempt communication with the now down master, to issue a new "saveof" command
-    to have it replicate from the new master.
+    This app is designed to switch between two machines both running redis as a main/subordinate setup
+    The goal is to be able to "toggle" back and forth between the machines.  When the "main" is no longer ping'able
+    we'll issue a "subordinateof no one" to the "subordinate".
+    It will then swap the ip address of the nginx load balancer to point to the new "main" node
+    The app will continue to attempt communication with the now down main, to issue a new "saveof" command
+    to have it replicate from the new main.
     I've tested this and it appears it works well to coordinate quick switches using a loadbalancer and the redis
     instances are able to pick up where they left off and keep going
 
     do a 
     kill -10 pid
-    to cause this to switch between the master and slave
+    to cause this to switch between the main and subordinate
 
 *   2017-09-15 NT   Created
-    2017-12-29 NT   Modified so there's a master who can be return a json of the current setup to a request
-                    Which allows a slave to copy the current master's setup
+    2017-12-29 NT   Modified so there's a main who can be return a json of the current setup to a request
+                    Which allows a subordinate to copy the current main's setup
                     This allows multiple load-balancers
 
 2018-07-05  NT  
     Redid config file and application to be a little more simple.  We know only have 2 servers, and they can have any number of
     redis ports between them.  The concept is that if a server is bad, we assume that all ports are bad and we switch all of them
 
-    Also this will now attempt to set a value in the database, to ensure that the server is actually running as the master.  If it fails
-    to set the value, then it will attempt to re-instate that server/port as the master
+    Also this will now attempt to set a value in the database, to ensure that the server is actually running as the main.  If it fails
+    to set the value, then it will attempt to re-instate that server/port as the main
 */
 
 package main
@@ -66,16 +66,16 @@ func loadConfig (config *appConfig_t, fileLoc string) {
 
     //validate the file makes sense
     //validate each redis server config, we'll actually try to resolve them later
-    if len(config.Master.PublicIP) < 1 { config.Master.PublicIP = config.Master.PrivateIP}
-    if len(config.Slave.PublicIP) < 1 { config.Slave.PublicIP = config.Slave.PrivateIP}
-    if len(config.Master.PrivateIP) < 1 { config.Master.PrivateIP = config.Master.PublicIP}
-    if len(config.Slave.PrivateIP) < 1 { config.Slave.PrivateIP = config.Slave.PublicIP}
+    if len(config.Main.PublicIP) < 1 { config.Main.PublicIP = config.Main.PrivateIP}
+    if len(config.Subordinate.PublicIP) < 1 { config.Subordinate.PublicIP = config.Subordinate.PrivateIP}
+    if len(config.Main.PrivateIP) < 1 { config.Main.PrivateIP = config.Main.PublicIP}
+    if len(config.Subordinate.PrivateIP) < 1 { config.Subordinate.PrivateIP = config.Subordinate.PublicIP}
 
-    if len(config.Master.PublicIP) < 7 { //not a real ip check, but we need something to verify it looks good
-        log.Fatalln("Master ip from redis server appears invalid")
+    if len(config.Main.PublicIP) < 7 { //not a real ip check, but we need something to verify it looks good
+        log.Fatalln("Main ip from redis server appears invalid")
     }
-    if len(config.Slave.PublicIP) < 7 { //not a real ip check, but we need something to verify it looks good
-        log.Fatalln("Slave ip from redis server index appears invalid")
+    if len(config.Subordinate.PublicIP) < 7 { //not a real ip check, but we need something to verify it looks good
+        log.Fatalln("Subordinate ip from redis server index appears invalid")
     }
     if len(config.Ports) < 1 {
         log.Fatalln("No ports are setup in the config")
@@ -89,7 +89,7 @@ func writeConfig (config *appConfig_t, fileLoc string) {
     if err != nil { log.Println(err) }
 }
 
-func masterEndpoint(w http.ResponseWriter, r *http.Request) {
+func mainEndpoint(w http.ResponseWriter, r *http.Request) {
     if r.Method == "OPTIONS" { return } //this is a "test" request sent by javascript to test if the call is valid, or something, so just ignore it
     js, _ := json.Marshal(appConfig)
     w.Write(js)
@@ -104,12 +104,12 @@ func main() {
     log.SetFlags(log.LstdFlags | log.Lshortfile) //configure the logging for this application
 	
 	versionFlag := flag.Bool("v", false, "Returns the version")
-	intervalFlag := flag.Int("i", 2, "Interval in seconds to check if the master is alive")
-    retryFlag := flag.Int("r", 2, "Interval in seconds to double check if the master is alive")
+	intervalFlag := flag.Int("i", 2, "Interval in seconds to check if the main is alive")
+    retryFlag := flag.Int("r", 2, "Interval in seconds to double check if the main is alive")
     configFlag := flag.String("c", "toggle.conf", "Location of the config file")
-    portFlag := flag.Int("p", 0, "Port for this master to return the current status. Also makes this act as a master")
-    slaveFlag := flag.Bool("slave", false, "Makes this instance run as a slave, only polls for changes, won't make them")
-    masterIPFlag := flag.String("master", "", "ip address of the master toggle service we're going to ask the settings of")
+    portFlag := flag.Int("p", 0, "Port for this main to return the current status. Also makes this act as a main")
+    subordinateFlag := flag.Bool("subordinate", false, "Makes this instance run as a subordinate, only polls for changes, won't make them")
+    mainIPFlag := flag.String("main", "", "ip address of the main toggle service we're going to ask the settings of")
     testFlag := flag.Bool("testing", false, "Creates the configs and writes to the log, but doesn't actually change anything.  Used for testing")
 	
 	flag.Parse()
@@ -132,7 +132,7 @@ func main() {
     signal.Notify(c, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
     //tickers for the tasks scheduled at intervals
-    ticker := time.NewTicker(time.Second * time.Duration(*intervalFlag))    //used for the master as well as the slave
+    ticker := time.NewTicker(time.Second * time.Duration(*intervalFlag))    //used for the main as well as the subordinate
     
     go func() { //handle exiting
         <-c
@@ -145,24 +145,24 @@ func main() {
         //}
     }()
 
-    if *slaveFlag {  //we're running as a slave, this is different.  
-        //We only poll the other server for the current master and copy the settings here
-        if *portFlag == 0 { log.Fatalln("Slave must have -p= set to the port the master is running on") }
-        if len(*masterIPFlag) < 7 { log.Fatalln("Master ip [--master=] appears invalid") }
+    if *subordinateFlag {  //we're running as a subordinate, this is different.  
+        //We only poll the other server for the current main and copy the settings here
+        if *portFlag == 0 { log.Fatalln("Subordinate must have -p= set to the port the main is running on") }
+        if len(*mainIPFlag) < 7 { log.Fatalln("Main ip [--main=] appears invalid") }
 
-        //slave task
+        //subordinate task
         go func() {
             lastIP := ""
             tasks := tasks_c{}
             nginx := nginx.Nginx_c{ TestingFlag: *testFlag }
 
             for range ticker.C {  //every time we "tick"
-                config, err := tasks.SlaveCheck (*masterIPFlag, *portFlag)
+                config, err := tasks.SubordinateCheck (*mainIPFlag, *portFlag)
                 if err == nil { //otherwise we ignore this
-                    if lastIP != config.Master.PrivateIP {  //we've had a switch
-                        log.Printf("Slave set config to %s\n", config.Master.PrivateIP)
-                        nginx.Set (config.Master.PrivateIP, config.Ports)    //update nginx to reflect this new setup
-                        lastIP = config.Master.PrivateIP //it changed, so save it
+                    if lastIP != config.Main.PrivateIP {  //we've had a switch
+                        log.Printf("Subordinate set config to %s\n", config.Main.PrivateIP)
+                        nginx.Set (config.Main.PrivateIP, config.Ports)    //update nginx to reflect this new setup
+                        lastIP = config.Main.PrivateIP //it changed, so save it
                     }
                 } else {
                     log.Println(err)    //we had an error
@@ -180,11 +180,11 @@ func main() {
     //first we want to validate our config so that tasks can run when we schedule it to
     tasks.ValidateConfig()  //if we don't throw a fatal, then we can keep going here
 
-    //signal for switching master/slave
+    //signal for switching main/subordinate
     switchSignal := make(chan os.Signal, 1)
     signal.Notify(switchSignal, syscall.SIGUSR1)
 	
-    //master task
+    //main task
 	go func() {
         for range ticker.C {  //every time we "tick"
             if tasks.Check() {    //main entry point
@@ -204,8 +204,8 @@ func main() {
 
     if *portFlag > 0 {
         go func() {
-            log.Println("Toggle running as master on port : ", *portFlag)
-            http.HandleFunc("/", masterEndpoint)
+            log.Println("Toggle running as main on port : ", *portFlag)
+            http.HandleFunc("/", mainEndpoint)
             http.ListenAndServe(fmt.Sprintf(":%d", *portFlag), nil)
         }()
     }

--- a/toggle/tasks.go
+++ b/toggle/tasks.go
@@ -26,8 +26,8 @@ type server_t struct {
 
 //app config for what we're monitoring
 type appConfig_t  struct {
-    Master  server_t  `json:"master"`
-    Slave   server_t  `json:"slave"`
+    Main  server_t  `json:"main"`
+    Subordinate   server_t  `json:"subordinate"`
     Ports   []int     `json:"ports"`
 }
 
@@ -42,12 +42,12 @@ type tasks_c struct {
  //----- PRIVATE FUNCTIONS -------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------------//
 
-func (t *tasks_c) checkRedis (ip string, port int, masterFlag bool) bool {
+func (t *tasks_c) checkRedis (ip string, port int, mainFlag bool) bool {
     r := redis.Redis_c { TestingFlag: t.TestingFlag }   //init a class
     err := r.Connect(ip, port)
     if err == nil {
         defer r.Close()
-        err = r.Check(masterFlag)
+        err = r.Check(mainFlag)
     }
     
     if err == nil {
@@ -58,29 +58,29 @@ func (t *tasks_c) checkRedis (ip string, port int, masterFlag bool) bool {
     }
 }
 
-/*! \brief Tells the targer server who their new master is
+/*! \brief Tells the targer server who their new main is
 */
-func (t *tasks_c) slaveof (targetIP string, targetPort int, newMasterIP, newMasterPort string) error {
+func (t *tasks_c) subordinateof (targetIP string, targetPort int, newMainIP, newMainPort string) error {
     r := redis.Redis_c { TestingFlag: t.TestingFlag }   //init a class
     err := r.Connect(targetIP, targetPort)  //connect to the server
 
     if err == nil {
         defer r.Close()
-        err = r.Slaveof(newMasterIP, newMasterPort)   //update the server to let it know who the new master is
+        err = r.Subordinateof(newMainIP, newMainPort)   //update the server to let it know who the new main is
     }
     return err
 }
 
-/*! \brief The goal here is to keep trying to tell the master that it's no longer the master
+/*! \brief The goal here is to keep trying to tell the main that it's no longer the main
     When this fails it ques itself up to try again
 */
-func (t *tasks_c) masterToSlave (targetIP, newMasterIP string, targetPort int) {
-    err := t.slaveof(targetIP, targetPort, newMasterIP, fmt.Sprintf("%d", targetPort))
+func (t *tasks_c) mainToSubordinate (targetIP, newMainIP string, targetPort int) {
+    err := t.subordinateof(targetIP, targetPort, newMainIP, fmt.Sprintf("%d", targetPort))
     if err != nil { //didn't work
         time.Sleep(time.Second * 5) //sleep here, time is less important as whenever the server comes back online it will start to replicate where it left off
-        go t.masterToSlave (targetIP, newMasterIP, targetPort)   //"recursive call", not actually recursive cause i was worried about a stack overflow
+        go t.mainToSubordinate (targetIP, newMainIP, targetPort)   //"recursive call", not actually recursive cause i was worried about a stack overflow
     } else {
-        log.Printf("Old master %s converted to slave of %s:%s", targetIP, newMasterIP, newMasterIP) //log that this completed
+        log.Printf("Old main %s converted to subordinate of %s:%s", targetIP, newMainIP, newMainIP) //log that this completed
     }
 }
 
@@ -89,42 +89,42 @@ func (t *tasks_c) masterToSlave (targetIP, newMasterIP string, targetPort int) {
 //-------------------------------------------------------------------------------------------------------------------------//
 
 /*! \brief Validates the config file.  Call this before you do a Check
-    This is intended to be called once at startup, this will validate that we can initially start communicating with at least the master server
-    We don't specifically care if we can't connect to the slave, although that is bad, we don't want that to prevent us from starting this service 
-    on account of a bad slave connection
+    This is intended to be called once at startup, this will validate that we can initially start communicating with at least the main server
+    We don't specifically care if we can't connect to the subordinate, although that is bad, we don't want that to prevent us from starting this service 
+    on account of a bad subordinate connection
 */
 func (t *tasks_c) ValidateConfig () {
     t.nginx.TestingFlag = t.TestingFlag //pass this down
 
     allGood := true     //default to this
     for _, port := range t.Config.Ports {
-        if t.checkRedis(t.Config.Master.PublicIP, port, true) == false {  //see if we can connect to the master
+        if t.checkRedis(t.Config.Main.PublicIP, port, true) == false {  //see if we can connect to the main
             allGood = false
-            break   //we couldn't connect to one of the master ports
+            break   //we couldn't connect to one of the main ports
         }
     }
 
-    if !allGood {   //this didn't work, so now try to connect to the slave instead
+    if !allGood {   //this didn't work, so now try to connect to the subordinate instead
         for _, port := range t.Config.Ports {
-            if t.checkRedis(t.Config.Slave.PublicIP, port, false) == false {  //see if we can connect to the slave
-                //this is really bad, we couldn't successfully connect to the master or the slave, so we have to bail
-                log.Fatalf("Unable to connect to master or slave on port %d\n", port)
+            if t.checkRedis(t.Config.Subordinate.PublicIP, port, false) == false {  //see if we can connect to the subordinate
+                //this is really bad, we couldn't successfully connect to the main or the subordinate, so we have to bail
+                log.Fatalf("Unable to connect to main or subordinate on port %d\n", port)
             }
         }
     }
 
-    if !allGood {   //in this case we couldn't talk to the master, but we could talk to the slave, so we want to switch them
+    if !allGood {   //in this case we couldn't talk to the main, but we could talk to the subordinate, so we want to switch them
         if !t.Switch() {
-            log.Fatalln("We were not able to convert the slave over to a master")
+            log.Fatalln("We were not able to convert the subordinate over to a main")
         }
     } else {
         //if we're here, it's cuase things are good, so update the nginx config file to match our config
-        t.nginx.Set(t.Config.Master.PublicIP, t.Config.Ports)
+        t.nginx.Set(t.Config.Main.PublicIP, t.Config.Ports)
 
-        //now make sure the servers are correctly identified as master/slave
+        //now make sure the servers are correctly identified as main/subordinate
         for _, port := range t.Config.Ports {
-            t.slaveof(t.Config.Master.PublicIP, port, "no", "one")
-            t.slaveof(t.Config.Slave.PublicIP, port, t.Config.Master.PrivateIP, fmt.Sprintf("%d", port))
+            t.subordinateof(t.Config.Main.PublicIP, port, "no", "one")
+            t.subordinateof(t.Config.Subordinate.PublicIP, port, t.Config.Main.PrivateIP, fmt.Sprintf("%d", port))
         }
     }
     log.Println("Config file validated")
@@ -134,41 +134,41 @@ func (t *tasks_c) ValidateConfig () {
 */
 func (t *tasks_c) Check () (ret bool) {
     for _, port := range t.Config.Ports {
-        if t.checkRedis(t.Config.Master.PublicIP, port, true) == false { //check the master first
-            //if we're here it's cause we couldn't connect with the master redis server
-            //we want to make sure we can connect with the slave as well, otherwise there's no point
-            if t.checkRedis(t.Config.Slave.PublicIP, port, false) {
-                //ok, so at this point we couldn't connect to the master, but we could the slave
-                //i like to be careful here, so i'm goign to try one more time for the master before we switch everything
-                //we passed in a -r flag to indicate the length of time to wait here before we check the master again
+        if t.checkRedis(t.Config.Main.PublicIP, port, true) == false { //check the main first
+            //if we're here it's cause we couldn't connect with the main redis server
+            //we want to make sure we can connect with the subordinate as well, otherwise there's no point
+            if t.checkRedis(t.Config.Subordinate.PublicIP, port, false) {
+                //ok, so at this point we couldn't connect to the main, but we could the subordinate
+                //i like to be careful here, so i'm goign to try one more time for the main before we switch everything
+                //we passed in a -r flag to indicate the length of time to wait here before we check the main again
                 time.Sleep(time.Second * time.Duration(t.Retry))
 
-                if t.checkRedis(t.Config.Master.PublicIP, port, true) == false {
+                if t.checkRedis(t.Config.Main.PublicIP, port, true) == false {
                     //ok, let's switch
-                    log.Printf("Switching away from old master at %s:%d\n", t.Config.Master.PublicIP, port)
+                    log.Printf("Switching away from old main at %s:%d\n", t.Config.Main.PublicIP, port)
                     ret = t.Switch()    //this actually handles switching
                 }
             } else {
-                log.Println("Lost connection to both master and slave")
+                log.Println("Lost connection to both main and subordinate")
             }
         }
     }
     return
 }
 
-/*! \brief Handles the process of switching between the slave and master
+/*! \brief Handles the process of switching between the subordinate and main
     essentially 2 things need to happen to make this work
-    we need to tell redis that it's now the master, which we'll do first cause it requires connecting to another machine
-    and then we need to update the nginx load balancer to switch the reverse proxy to the new slave ip address
-    and of course once that's done we want to update our config file to reflect the fact that the master and slave has switched
+    we need to tell redis that it's now the main, which we'll do first cause it requires connecting to another machine
+    and then we need to update the nginx load balancer to switch the reverse proxy to the new subordinate ip address
+    and of course once that's done we want to update our config file to reflect the fact that the main and subordinate has switched
 */
 func (t *tasks_c) Switch () bool {
     var err error
     for _, port := range t.Config.Ports {
-        err = t.slaveof(t.Config.Slave.PublicIP, port, "no", "one")   //special no one for indicating it's a master
+        err = t.subordinateof(t.Config.Subordinate.PublicIP, port, "no", "one")   //special no one for indicating it's a main
         if err == nil {
-            //now we need to keep trying to talk to the master server and to let it know it's no longer the master
-            t.masterToSlave(t.Config.Master.PublicIP, t.Config.Slave.PrivateIP, port)
+            //now we need to keep trying to talk to the main server and to let it know it's no longer the main
+            t.mainToSubordinate(t.Config.Main.PublicIP, t.Config.Subordinate.PrivateIP, port)
         } else {
             break   //don't do anymore, we're done
         }
@@ -176,25 +176,25 @@ func (t *tasks_c) Switch () bool {
 
     if err == nil { //if this worked, then we're committed
         //now update ngnix
-        t.nginx.Set(t.Config.Slave.PublicIP, t.Config.Ports)
+        t.nginx.Set(t.Config.Subordinate.PublicIP, t.Config.Ports)
 
-        log.Printf("Switch completed to new master at %s\n", t.Config.Slave.PublicIP)  //we're done
-        t.Config.Master, t.Config.Slave = t.Config.Slave, t.Config.Master   //switch the values so we know which is the master and which is the slave now
+        log.Printf("Switch completed to new main at %s\n", t.Config.Subordinate.PublicIP)  //we're done
+        t.Config.Main, t.Config.Subordinate = t.Config.Subordinate, t.Config.Main   //switch the values so we know which is the main and which is the subordinate now
         return true //indicates we need to write this new update to the config file
     } else {
-        log.Printf("Unable to promote slave to master, we're in bad shape: %s \n", err.Error()) //this is really bad
+        log.Printf("Unable to promote subordinate to main, we're in bad shape: %s \n", err.Error()) //this is really bad
     }
     return false    //this is bad
 }
 
-/*! \brief This gets the current settings from the master ip and port for redis
+/*! \brief This gets the current settings from the main ip and port for redis
     This will return ip, port, error
 */
-func (t *tasks_c) SlaveCheck (ip string, port int) (config appConfig_t, err error) {
-    //we need to do a get request from the master to see what the settings are
+func (t *tasks_c) SubordinateCheck (ip string, port int) (config appConfig_t, err error) {
+    //we need to do a get request from the main to see what the settings are
     req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d", ip, port), nil)
     if err != nil {
-        log.Printf("Slave request for master's data failed: %s:%d : %s\n", ip, port, err.Error())
+        log.Printf("Subordinate request for main's data failed: %s:%d : %s\n", ip, port, err.Error())
         return
     }
     
@@ -204,7 +204,7 @@ func (t *tasks_c) SlaveCheck (ip string, port int) (config appConfig_t, err erro
     
     resp, err := client.Do(req)
     if err != nil {
-        log.Printf("Slave request Failed: %s:%d : %s\n", ip, port, err.Error())
+        log.Printf("Subordinate request Failed: %s:%d : %s\n", ip, port, err.Error())
         return
     }
     
@@ -215,7 +215,7 @@ func (t *tasks_c) SlaveCheck (ip string, port int) (config appConfig_t, err erro
     //fmt.Println("response Body:", string(body))
     
     if resp.StatusCode > 299 {
-        err = fmt.Errorf("Slave request Failed code : %d : %s:%d\n", resp.StatusCode, ip, port)
+        err = fmt.Errorf("Subordinate request Failed code : %d : %s:%d\n", resp.StatusCode, ip, port)
     } else {
         err = json.NewDecoder(resp.Body).Decode(&config)   //unencode the object
     }


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.